### PR TITLE
补齐旧版实体迁移并避免网关初始化阻塞

### DIFF
--- a/custom_components/ds_air/__init__.py
+++ b/custom_components/ds_air/__init__.py
@@ -8,6 +8,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import (
@@ -187,7 +188,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     service = Service()
     hass.data[DOMAIN][entry.entry_id] = service
-    await hass.async_add_executor_job(service.init, host, port, scan_interval, config)
+    try:
+        await hass.async_add_executor_job(
+            service.init, host, port, scan_interval, config
+        )
+    except TimeoutError as exc:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        raise ConfigEntryNotReady(str(exc)) from exc
     _migrate_legacy_sensor_links(hass, entry, service)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))

--- a/custom_components/ds_air/__init__.py
+++ b/custom_components/ds_air/__init__.py
@@ -8,16 +8,17 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import (
     CONF_GW,
     DEFAULT_GW,
     DOMAIN,
     MANUFACTURER,
-    get_default_gateway_name,
 )
+from .descriptions import SENSOR_DESCRIPTORS
 from .ds_air_service import Config, Service
+from .ds_air_service.dao import migrate_legacy_sensor_links, migrate_legacy_unique_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +26,141 @@ PLATFORMS = [
     Platform.CLIMATE,
     Platform.SENSOR,
 ]
+
+
+def _migrate_entity_registry_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, gateway_id: str
+) -> None:
+    entity_registry = er.async_get(hass)
+
+    for entity_entry in er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    ):
+        if not isinstance(entity_entry.unique_id, str):
+            continue
+
+        new_unique_id = migrate_legacy_unique_id(
+            entity_entry.unique_id, gateway_id, SENSOR_DESCRIPTORS
+        )
+        if new_unique_id is None:
+            continue
+
+        conflict_entity_id = entity_registry.async_get_entity_id(
+            entity_entry.domain, entity_entry.platform, new_unique_id
+        )
+        if conflict_entity_id and conflict_entity_id != entity_entry.entity_id:
+            _LOGGER.warning(
+                "Unable to migrate entity %s unique_id to %s: already used by %s",
+                entity_entry.entity_id,
+                new_unique_id,
+                conflict_entity_id,
+            )
+            continue
+
+        entity_registry.async_update_entity(
+            entity_entry.entity_id, new_unique_id=new_unique_id
+        )
+
+
+def _migrate_device_registry_identifiers(
+    hass: HomeAssistant, entry: ConfigEntry, gateway_id: str
+) -> None:
+    device_registry = dr.async_get(hass)
+
+    for device_entry in dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    ):
+        identifiers = set(device_entry.identifiers)
+        new_identifiers = set()
+
+        for domain, identifier in identifiers:
+            if domain != DOMAIN:
+                new_identifiers.add((domain, identifier))
+                continue
+
+            new_identifier = migrate_legacy_unique_id(
+                identifier, gateway_id, SENSOR_DESCRIPTORS
+            )
+            if new_identifier is not None:
+                conflict_device = device_registry.async_get_device(
+                    identifiers={(domain, new_identifier)}
+                )
+                if conflict_device and conflict_device.id != device_entry.id:
+                    _LOGGER.warning(
+                        "Unable to migrate device %s identifier to %s: already used by %s",
+                        device_entry.id,
+                        new_identifier,
+                        conflict_device.id,
+                    )
+                    new_identifier = None
+            new_identifiers.add((domain, new_identifier or identifier))
+
+        if new_identifiers != identifiers:
+            device_registry.async_update_device(
+                device_entry.id, new_identifiers=new_identifiers
+            )
+
+
+def _migrate_options_unique_ids(options: dict, gateway_id: str) -> tuple[dict, bool]:
+    links = options.get("link")
+    if not isinstance(links, list):
+        return options, False
+
+    changed = False
+    migrated_links = []
+    for link in links:
+        if not isinstance(link, dict):
+            migrated_links.append(link)
+            continue
+
+        migrated_link = dict(link)
+        climate_id = migrated_link.get("climate")
+        if isinstance(climate_id, str):
+            new_climate_id = migrate_legacy_unique_id(climate_id, gateway_id)
+            if new_climate_id is not None:
+                migrated_link["climate"] = new_climate_id
+                changed = True
+        migrated_links.append(migrated_link)
+
+    if not changed:
+        return options, False
+    return {**options, "link": migrated_links}, True
+
+
+def _migrate_legacy_sensor_links(
+    hass: HomeAssistant, entry: ConfigEntry, service: Service
+) -> None:
+    links = entry.options.get("link")
+    if not isinstance(links, list):
+        return
+
+    migrated_links, changed = migrate_legacy_sensor_links(links, service.get_aircons())
+    if changed:
+        hass.config_entries.async_update_entry(
+            entry, options={**entry.options, "link": migrated_links}
+        )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries to gateway-scoped unique IDs."""
+    if entry.version > 2:
+        return False
+    if entry.version == 2:
+        return True
+
+    gateway_id = entry.entry_id
+    _migrate_entity_registry_unique_ids(hass, entry, gateway_id)
+    _migrate_device_registry_identifiers(hass, entry, gateway_id)
+
+    options, options_changed = _migrate_options_unique_ids(
+        dict(entry.options), gateway_id
+    )
+    update = {"version": 2}
+    if options_changed:
+        update["options"] = options
+
+    hass.config_entries.async_update_entry(entry, **update)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -52,6 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     service = Service()
     hass.data[DOMAIN][entry.entry_id] = service
     await hass.async_add_executor_job(service.init, host, port, scan_interval, config)
+    _migrate_legacy_sensor_links(hass, entry, service)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))
 

--- a/custom_components/ds_air/config_flow.py
+++ b/custom_components/ds_air/config_flow.py
@@ -38,7 +38,7 @@ def _log(s: str) -> None:
 
 
 class DsAirFlowHandler(ConfigFlow, domain=DOMAIN):
-    VERSION = 1
+    VERSION = 2
 
     def __init__(self):
         self.user_input = {}

--- a/custom_components/ds_air/ds_air_service/dao.py
+++ b/custom_components/ds_air/ds_air_service/dao.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Iterable
 
 from .config import Config
 from .ctrl_enum import (
@@ -13,6 +14,57 @@ from .ctrl_enum import (
 
 def build_device_unique_id(gateway_id: str, room_id: int, unit_id: int) -> str:
     return f"daikin_{gateway_id}_{room_id}_{unit_id}"
+
+
+def migrate_legacy_unique_id(
+    unique_id: str, gateway_id: str, sensor_keys: Iterable[str] = ()
+) -> str | None:
+    parts = unique_id.split("_")
+    if len(parts) == 3 and parts[0] == "daikin":
+        room_id, unit_id = parts[1:]
+        if room_id.isdigit() and unit_id.isdigit():
+            return build_device_unique_id(gateway_id, int(room_id), int(unit_id))
+
+    for sensor_key in sensor_keys:
+        prefix = f"{sensor_key}_"
+        if not unique_id.startswith(prefix):
+            continue
+        migrated_device_id = migrate_legacy_unique_id(
+            unique_id.removeprefix(prefix), gateway_id
+        )
+        if migrated_device_id is not None:
+            return f"{sensor_key}_{migrated_device_id}"
+
+    return None
+
+
+def migrate_legacy_sensor_links(
+    links: list, aircons: Iterable["Device"]
+) -> tuple[list, bool]:
+    alias_to_unique_id = {
+        aircon.alias: aircon.unique_id for aircon in aircons if aircon.alias
+    }
+    unique_ids = {aircon.unique_id for aircon in aircons}
+    migrated_links = []
+    changed = False
+
+    for link in links:
+        if not isinstance(link, dict):
+            migrated_links.append(link)
+            continue
+
+        migrated_link = dict(link)
+        climate_id = migrated_link.get("climate")
+        if (
+            isinstance(climate_id, str)
+            and climate_id not in unique_ids
+            and climate_id in alias_to_unique_id
+        ):
+            migrated_link["climate"] = alias_to_unique_id[climate_id]
+            changed = True
+        migrated_links.append(migrated_link)
+
+    return migrated_links, changed
 
 
 def build_aircon_device_name(alias: str) -> str:

--- a/custom_components/ds_air/ds_air_service/service.py
+++ b/custom_components/ds_air/ds_air_service/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import logging
 import socket
-from threading import Lock, Thread
+from threading import Event, Lock, Thread
 import time
 
 from .config import Config
@@ -21,6 +21,9 @@ from .param import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+INIT_TIMEOUT_SECONDS = 60.0
+SOCKET_TIMEOUT_SECONDS = 5.0
+CONNECT_RETRY_INTERVAL_SECONDS = 3.0
 
 
 def _log(s: str):
@@ -30,49 +33,82 @@ def _log(s: str):
 
 
 class SocketClient:
-    def __init__(self, host: str, port: int, service: Service, config: Config):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        service: Service,
+        config: Config,
+        deadline: float | None = None,
+    ):
         self._host = host
         self._port = port
         self._config = config
         self._locker = Lock()
         self._s = None
-        while not self.do_connect():
-            time.sleep(3)
+        self._ready = False
+        self._recv_thread = None
+        while not self.do_connect(deadline):
+            self._raise_if_expired(deadline, "connecting")
+            time.sleep(self._retry_sleep(deadline))
         self._ready = True
         self._recv_thread = RecvThread(self, service)
         self._recv_thread.start()
 
     def destroy(self):
         self._ready = False
-        self._recv_thread.terminate()
-        self._s.close()
+        if self._recv_thread is not None:
+            self._recv_thread.terminate()
+            self._recv_thread = None
+        if self._s is not None:
+            self._s.close()
+            self._s = None
 
-    def do_connect(self):
+    def _raise_if_expired(self, deadline: float | None, action: str) -> None:
+        if deadline is not None and time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Timed out {action} to DS-AIR gateway {self._host}:{self._port}"
+            )
+
+    def _retry_sleep(self, deadline: float | None) -> float:
+        if deadline is None:
+            return CONNECT_RETRY_INTERVAL_SECONDS
+        return min(CONNECT_RETRY_INTERVAL_SECONDS, max(0.0, deadline - time.monotonic()))
+
+    def do_connect(self, deadline: float | None = None):
+        self._raise_if_expired(deadline, "connecting")
         self._s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        timeout = SOCKET_TIMEOUT_SECONDS
+        if deadline is not None:
+            timeout = min(timeout, max(0.001, deadline - time.monotonic()))
+        self._s.settimeout(timeout)
         try:
             self._s.connect((self._host, self._port))
         except OSError as exc:
             _log("connected error")
             _log(str(exc))
+            self._s.close()
+            self._s = None
             return False
         else:
             _log("connected")
             return True
 
-    def send(self, p: Param):
-        self._locker.acquire()
-        _log("send hex: 0x" + p.to_string(self._config).hex())
-        _log("\033[31msend:\033[0m")
-        _log(display(p))
-        done = False
-        while not done:
-            try:
-                self._s.sendall(p.to_string(self._config))
-                done = True
-            except Exception:
-                time.sleep(3)
-                self.do_connect()
-        self._locker.release()
+    def send(self, p: Param, deadline: float | None = None):
+        data = p.to_string(self._config)
+        with self._locker:
+            _log("send hex: 0x" + data.hex())
+            _log("\033[31msend:\033[0m")
+            _log(display(p))
+            done = False
+            while not done:
+                self._raise_if_expired(deadline, "sending")
+                try:
+                    self._s.sendall(data)
+                    done = True
+                except Exception:
+                    time.sleep(self._retry_sleep(deadline))
+                    self.do_connect(deadline)
 
     def recv(self) -> (list[BaseResult], bytes):
         res = []
@@ -132,13 +168,16 @@ class HeartBeatThread(Thread):
         super().__init__()
         self.service = service
         self._running = True
+        self._stop_event = Event()
 
     def terminate(self):
         self._running = False
+        self._stop_event.set()
 
     def run(self) -> None:
         super().run()
-        time.sleep(30)
+        if self._stop_event.wait(30):
+            return
         cnt = 0
         while self._running:
             self.service.send_msg(HeartbeatParam())
@@ -148,7 +187,8 @@ class HeartBeatThread(Thread):
                 cnt = 0
                 self.service.poll_status()
 
-            time.sleep(60)
+            if self._stop_event.wait(60):
+                return
 
 
 class Service:
@@ -167,56 +207,76 @@ class Service:
         self._scan_interval: int = 5
         self.state_change_listener: Callable[[], None] | None = None
 
-    def init(self, host: str, port: int, scan_interval: int, config: Config) -> None:
+    def init(
+        self,
+        host: str,
+        port: int,
+        scan_interval: int,
+        config: Config,
+        timeout: float | None = INIT_TIMEOUT_SECONDS,
+    ) -> None:
         if self._ready:
             return
-        self._scan_interval = scan_interval
-        self._socket_client = SocketClient(host, port, self, config)
-        self._socket_client.send(HandShakeParam())
-        self._heartbeat_thread = HeartBeatThread(self)
-        self._heartbeat_thread.start()
-        while (
-            self._rooms is None
-            or self._aircons is None
-            or self._new_aircons is None
-            or self._bathrooms is None
-        ):
-            time.sleep(1)
-        for i in self._aircons:
-            for j in self._rooms:
-                if i.room_id == j.id:
-                    i.alias = j.alias
-                    if i.unit_id:
-                        i.alias += str(i.unit_id)
-        for i in self._new_aircons:
-            for j in self._rooms:
-                if i.room_id == j.id:
-                    i.alias = j.alias
-                    if i.unit_id:
-                        i.alias += str(i.unit_id)
-        for i in self._bathrooms:
-            for j in self._rooms:
-                if i.room_id == j.id:
-                    i.alias = j.alias
-                    if i.unit_id:
-                        i.alias += str(i.unit_id)
-        self._ready = True
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        try:
+            self._scan_interval = scan_interval
+            self._socket_client = SocketClient(host, port, self, config, deadline)
+            self._socket_client.send(HandShakeParam(), deadline)
+            self._heartbeat_thread = HeartBeatThread(self)
+            self._heartbeat_thread.start()
+            while (
+                self._rooms is None
+                or self._aircons is None
+                or self._new_aircons is None
+                or self._bathrooms is None
+            ):
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out initializing DS-AIR gateway {host}:{port}"
+                    )
+                if deadline is None:
+                    time.sleep(1)
+                else:
+                    time.sleep(min(1, max(0.0, deadline - time.monotonic())))
+            for i in self._aircons:
+                for j in self._rooms:
+                    if i.room_id == j.id:
+                        i.alias = j.alias
+                        if i.unit_id:
+                            i.alias += str(i.unit_id)
+            for i in self._new_aircons:
+                for j in self._rooms:
+                    if i.room_id == j.id:
+                        i.alias = j.alias
+                        if i.unit_id:
+                            i.alias += str(i.unit_id)
+            for i in self._bathrooms:
+                for j in self._rooms:
+                    if i.room_id == j.id:
+                        i.alias = j.alias
+                        if i.unit_id:
+                            i.alias += str(i.unit_id)
+            self._ready = True
+        except Exception:
+            self.destroy()
+            raise
 
     def destroy(self) -> None:
-        if self._ready:
+        if self._heartbeat_thread is not None:
             self._heartbeat_thread.terminate()
+            self._heartbeat_thread = None
+        if self._socket_client is not None:
             self._socket_client.destroy()
             self._socket_client = None
-            self._rooms = None
-            self._aircons = None
-            self._new_aircons = None
-            self._bathrooms = None
-            self._none_stat_dev_cnt = 0
-            self._status_hook = []
-            self._sensor_hook = []
-            self._heartbeat_thread = None
-            self._sensors = []
-            self._ready = False
+        self._rooms = None
+        self._aircons = None
+        self._new_aircons = None
+        self._bathrooms = None
+        self._none_stat_dev_cnt = 0
+        self._status_hook = []
+        self._sensor_hook = []
+        self._sensors = []
+        self._ready = False
 
     def get_aircons(self) -> list[AirCon]:
         aircons = []

--- a/tests/test_unique_ids.py
+++ b/tests/test_unique_ids.py
@@ -6,6 +6,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "custom_components" / "ds_air"))
 
+from ds_air_service import dao  # noqa: E402
 from ds_air_service.dao import Device  # noqa: E402
 from ds_air_service.dao import build_aircon_device_name  # noqa: E402
 from ds_air_service.dao import build_sensor_device_name  # noqa: E402
@@ -31,6 +32,39 @@ class UniqueIdTests(unittest.TestCase):
         self.assertEqual(build_aircon_device_name("客厅"), "客厅 空调")
         self.assertEqual(build_aircon_device_name("客厅空调"), "客厅空调")
         self.assertEqual(build_sensor_device_name("客厅"), "客厅 传感器")
+
+    def test_legacy_registry_unique_ids_migrate_to_gateway_scoped_ids(self):
+        self.assertEqual(
+            dao.migrate_legacy_unique_id("daikin_1_0", "entry_a", {"temp"}),
+            "daikin_entry_a_1_0",
+        )
+        self.assertEqual(
+            dao.migrate_legacy_unique_id("temp_daikin_1_0", "entry_a", {"temp"}),
+            "temp_daikin_entry_a_1_0",
+        )
+        self.assertIsNone(
+            dao.migrate_legacy_unique_id(
+                "temp_daikin_entry_a_1_0", "entry_a", {"temp"}
+            )
+        )
+
+    def test_legacy_alias_sensor_links_migrate_to_climate_unique_ids(self):
+        device = Device()
+        device.gateway_id = "entry_a"
+        device.room_id = 1
+        device.unit_id = 0
+        device.alias = "客厅"
+
+        links, changed = dao.migrate_legacy_sensor_links(
+            [{"climate": "客厅", "sensor_temp": "sensor.temp"}],
+            [device],
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(
+            links,
+            [{"climate": "daikin_entry_a_1_0", "sensor_temp": "sensor.temp"}],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景
上游已合并此前多网关唯一标识相关变更的一部分，本 PR 补齐后续兼容迁移和初始化超时处理。

## 变更
- 将旧版 registry unique_id / device identifier 从 `daikin_{room}_{unit}`、`{sensor_key}_daikin_{room}_{unit}` 迁移到包含 config entry id 的新格式，尽量保留原 entity_id、命名、区域和自动化引用。
- 迁移旧 options 中按空调 alias 保存的传感器绑定，更新为 climate unique_id，避免重名分机绑定歧义。
- 给网关初始化增加有限超时和清理，超时后抛出 `ConfigEntryNotReady` 交给 HA 重试，避免网关 IP 失效或暂不可达时阻塞 HA 启动。

## 验证
- `python3 tests/test_unique_ids.py`
- `python3 -m compileall custom_components`