### PR TITLE
修复 DTA117D611 新风传感器解析并增加新风控制实体

### DIFF
--- a/custom_components/ds_air/__init__.py
+++ b/custom_components/ds_air/__init__.py
@@ -29,6 +29,7 @@ PLATFORMS = [
     Platform.CLIMATE,
     Platform.SENSOR,
     Platform.FAN,
+    Platform.SELECT,
     Platform.SWITCH,
     Platform.WATER_HEATER,
 ]

--- a/custom_components/ds_air/const.py
+++ b/custom_components/ds_air/const.py
@@ -96,8 +96,28 @@ def get_fan_direction_enum(name: str) -> EnumControl.FanDirection:
 
 # 新风传感器类型
 SMALL_VAM_SENSOR_TYPES = {
-    "in_door_temp": [UnitOfTemperature.CELSIUS, None, SensorDeviceClass.TEMPERATURE, 10],
-    "out_door_temp": [UnitOfTemperature.CELSIUS, None, SensorDeviceClass.TEMPERATURE, 10],
-    "out_door_humidity": [PERCENTAGE, None, SensorDeviceClass.HUMIDITY, 1],
-    "pm25": [CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, None, SensorDeviceClass.PM25, 1],
+    "in_door_temp": [
+        UnitOfTemperature.CELSIUS,
+        "indoor_temperature",
+        SensorDeviceClass.TEMPERATURE,
+        10,
+    ],
+    "out_door_temp": [
+        UnitOfTemperature.CELSIUS,
+        "outdoor_temperature",
+        SensorDeviceClass.TEMPERATURE,
+        10,
+    ],
+    "out_door_humidity": [
+        PERCENTAGE,
+        "outdoor_humidity",
+        SensorDeviceClass.HUMIDITY,
+        1,
+    ],
+    "pm25": [
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        "outdoor_pm25",
+        SensorDeviceClass.PM25,
+        1,
+    ],
 }

--- a/custom_components/ds_air/ds_air_service/decoder.py
+++ b/custom_components/ds_air/ds_air_service/decoder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import struct
 from typing import TYPE_CHECKING
 
@@ -46,6 +47,8 @@ from .param import (
 
 if TYPE_CHECKING:
     from .service import Service
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def decoder(b: bytes, config: Config):
@@ -216,6 +219,112 @@ class Decode:
         pos += length
         self._pos = pos
         return s
+
+
+def _parse_tlv_items(
+    b: bytes, start: int, max_size: int = 32
+) -> tuple[dict[int, int], int] | None:
+    pos = start
+    items: dict[int, int] = {}
+    while pos < len(b):
+        item_type = b[pos]
+        pos += 1
+        if item_type == 0:
+            return items, pos
+        if pos >= len(b):
+            return None
+
+        size = b[pos]
+        pos += 1
+        if size > max_size or pos + size > len(b):
+            return None
+
+        raw = b[pos : pos + size]
+        pos += size
+        if size <= 8:
+            items[item_type] = int.from_bytes(raw, "little")
+
+    return None
+
+
+def _is_readable_name(value: str) -> bool:
+    return bool(value) and all(char.isprintable() for char in value)
+
+
+def _find_d611_named_sensor_tlv(b: bytes) -> dict[int, int] | None:
+    best: tuple[int, dict[int, int], str] | None = None
+    for pos, name_len in enumerate(b):
+        if name_len == 0 or name_len > 32 or pos + 1 + name_len > len(b):
+            continue
+        raw_name = b[pos + 1 : pos + 1 + name_len]
+        try:
+            name = raw_name.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        if not _is_readable_name(name):
+            continue
+
+        tlv_start = pos + 1 + name_len
+        parsed = _parse_tlv_items(b, tlv_start)
+        if parsed is None:
+            continue
+        items, _end = parsed
+        score = sum(field in items for field in (1, 2, 3, 4))
+        if score < 2:
+            continue
+        if best is None or score > best[0]:
+            best = (score, items, name)
+
+    if best is None:
+        return None
+
+    _LOGGER.debug("[DS-AIR VAM D611] named sensor block %s: %s", best[2], best[1])
+    return best[1]
+
+
+def _find_d611_front_tlv(b: bytes) -> dict[int, int] | None:
+    best: tuple[int, int, dict[int, int]] | None = None
+    for start in range(2, min(len(b), 20)):
+        parsed = _parse_tlv_items(b, start)
+        if parsed is None:
+            continue
+        items, _end = parsed
+        score = sum(field in items for field in (5, 6, 7))
+        if score == 0:
+            continue
+        unknown_count = len([field for field in items if field not in (5, 6, 7)])
+        candidate = (score, -unknown_count, items)
+        if best is None or candidate[:2] > best[:2]:
+            best = candidate
+
+    if best is None:
+        return None
+
+    _LOGGER.debug("[DS-AIR VAM D611] front block: %s", best[2])
+    return best[2]
+
+
+def _parse_d611_vam_composite_status(b: bytes) -> VentilationStatus | None:
+    if len(b) < 4:
+        return None
+
+    front = _find_d611_front_tlv(b)
+    named_sensor = _find_d611_named_sensor_tlv(b)
+    if front is None and named_sensor is None:
+        return None
+
+    status = VentilationStatus()
+    if named_sensor is not None and 1 in named_sensor:
+        status.in_door_temp = named_sensor[1]
+    if front is not None:
+        if 5 in front:
+            status.out_door_temp = front[5]
+        if 6 in front:
+            status.out_door_humidity = front[6]
+        if 7 in front:
+            status.pm25 = front[7]
+
+    return status
 
 
 class BaseResult(BaseBean):
@@ -1039,24 +1148,35 @@ class VentilationQueryCompositeSituationResult(BaseResult):
         self._pm25: int = UNINITIALIZED_VALUE
 
     def load_bytes(self, b: bytes, config: Config) -> None:
-        d = Decode(b)
-        self._room = d.read1()
-        self._unit = d.read1()
-        statusType = d.read1()
-        statusSize = d.read1()
-        while statusType != 0:
-            if statusType == 1 and statusSize == 2:
-                self._in_door_temp = d.read2()
-            elif statusType == 2 and statusSize == 2:
-                self._out_door_humidity = d.read2()
-            elif statusType == 3 and statusSize == 2:
-                pass  # 不知道干什么用的数据
-            elif statusType == 4 and statusSize == 2:
-                self._pm25 = d.read2()
-            else:
-                d.read(statusSize)
-            statusType = d.read1()
-            statusSize = d.read1()
+        if config.is_d611:
+            status = _parse_d611_vam_composite_status(b)
+            if status is not None:
+                self._room = b[0]
+                self._unit = b[1]
+                self._in_door_temp = status.in_door_temp
+                self._out_door_temp = status.out_door_temp
+                self._out_door_humidity = status.out_door_humidity
+                self._pm25 = status.pm25
+                return
+
+        if len(b) < 2:
+            return
+
+        self._room = b[0]
+        self._unit = b[1]
+        parsed = _parse_tlv_items(b, 2)
+        if parsed is None:
+            return
+
+        items, _end = parsed
+        if 1 in items:
+            self._in_door_temp = items[1]
+        if 2 in items:
+            self._out_door_humidity = items[2]
+        if 3 in items:
+            self._out_door_temp = items[3]
+        if 4 in items:
+            self._pm25 = items[4]
 
     def do(self, service: Service) -> None:
         status = VentilationStatus(

--- a/custom_components/ds_air/fan.py
+++ b/custom_components/ds_air/fan.py
@@ -69,10 +69,12 @@ class DsVent(FanEntity):
         _log("create ventilation:")
         _log(vent.__dict__)
         _log(vent.status)
-        self._name = vent.alias
+        self._device_name = f"新风 {vent.alias}"
         self._device_info = vent
         self._unique_id = vent.unique_id
         self._service = service
+        self._attr_has_entity_name = True
+        self._attr_translation_key = "ventilation_switch"
 
         # Set supported features
         if vent.is_small_vam:
@@ -93,6 +95,7 @@ class DsVent(FanEntity):
         if kwargs.get("vent") is not None:
             vent: Ventilation = kwargs["vent"]
             self._device_info = vent
+            self._device_name = f"新风 {vent.alias}"
             _log(display(self._device_info))
 
         if kwargs.get("status") is not None:
@@ -117,11 +120,6 @@ class DsVent(FanEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
-        """Get entity name."""
-        return self._name
-
-    @property
     def should_poll(self) -> bool:
         """No polling needed."""
         return False
@@ -131,7 +129,7 @@ class DsVent(FanEntity):
         """Return device info."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._unique_id)},
-            name=f"新风 {self._name}",
+            name=self._device_name,
             manufacturer="Daikin Industries, Ltd.",
         )
 

--- a/custom_components/ds_air/select.py
+++ b/custom_components/ds_air/select.py
@@ -1,0 +1,184 @@
+"""Select entities for DS-AIR ventilation devices."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, MANUFACTURER
+from .ds_air_service import (
+    EnumControl,
+    Service,
+    get_vent_mode_enum_small_vam,
+    get_vent_mode_enum_standard_vam,
+    get_vent_mode_name_small_vam,
+    get_vent_mode_name_standard_vam,
+)
+from .ds_air_service.dao import Ventilation, VentilationStatus
+
+_LOGGER = logging.getLogger(__name__)
+
+_MODE_VENT_NAME_LIST_SMALL_VAM = ["内循环", "热交换", "自动", "防污染", "排异味"]
+_MODE_VENT_NAME_LIST_STANDARD_VAM = ["旁通", "热交换", "自动"]
+_VENT_AIR_FLOW_OPTIONS_SMALL_VAM = ["静音", "中速", "高速", "暴风"]
+_VENT_AIR_FLOW_OPTIONS_STANDARD_VAM = ["静音", "中速", "高速"]
+_VENT_AIR_FLOW_BY_OPTION = {
+    "静音": EnumControl.AirFlow.WEAK,
+    "中速": EnumControl.AirFlow.MIDDLE,
+    "高速": EnumControl.AirFlow.STRONG,
+    "暴风": EnumControl.AirFlow.SUPER_STRONG,
+}
+_VENT_AIR_FLOW_BY_ENUM = {
+    value: option for option, value in _VENT_AIR_FLOW_BY_OPTION.items()
+}
+
+
+def _log(value) -> None:
+    value = str(value)
+    for line in value.split("\n"):
+        _LOGGER.debug(line)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up DS-AIR select entities."""
+    service: Service = hass.data[DOMAIN][config_entry.entry_id]
+    entities = []
+    for vent in service.get_ventilations():
+        entities.append(DsVentModeSelect(vent, service))
+        entities.append(DsVentAirFlowSelect(vent, service))
+    async_add_entities(entities)
+
+
+class DsVentModeSelect(SelectEntity):
+    """Ventilation mode selector."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "ventilation_mode"
+    _attr_should_poll = False
+
+    def __init__(self, vent: Ventilation, service: Service) -> None:
+        self._device_info = vent
+        self._service = service
+        self._attr_unique_id = f"mode_{vent.unique_id}"
+
+        if vent.is_small_vam:
+            self._attr_options = _MODE_VENT_NAME_LIST_SMALL_VAM
+        else:
+            self._attr_options = _MODE_VENT_NAME_LIST_STANDARD_VAM
+
+        service.register_vent_hook(vent, self._status_change_hook)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_info.unique_id)},
+            name=f"新风 {self._device_info.alias}",
+            manufacturer=MANUFACTURER,
+            via_device=(DOMAIN, self._device_info.gateway_id),
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current selected option."""
+        mode = self._device_info.status.mode
+        if mode is None:
+            return None
+        if self._device_info.is_small_vam:
+            return get_vent_mode_name_small_vam(mode)
+        return get_vent_mode_name_standard_vam(mode)
+
+    def select_option(self, option: str) -> None:
+        """Select ventilation mode."""
+        if self._device_info.is_small_vam:
+            mode = get_vent_mode_enum_small_vam(option)
+        else:
+            mode = get_vent_mode_enum_standard_vam(option)
+
+        self._device_info.status.mode = mode
+        self._service.control_vent(
+            self._device_info,
+            VentilationStatus(mode=mode),
+        )
+        self.schedule_update_ha_state()
+
+    def _status_change_hook(self, **kwargs) -> None:
+        """Handle ventilation status changes."""
+        if kwargs.get("vent") is not None:
+            self._device_info = kwargs["vent"]
+
+        if kwargs.get("status") is not None:
+            new_status: VentilationStatus = kwargs["status"]
+            if new_status.mode is not None:
+                self._device_info.status.mode = new_status.mode
+
+        _log(f"vent mode select updated: {self.current_option}")
+        self.schedule_update_ha_state()
+
+
+class DsVentAirFlowSelect(SelectEntity):
+    """Ventilation air flow selector."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "ventilation_air_flow"
+    _attr_should_poll = False
+
+    def __init__(self, vent: Ventilation, service: Service) -> None:
+        self._device_info = vent
+        self._service = service
+        self._attr_unique_id = f"air_flow_{vent.unique_id}"
+        if vent.is_small_vam:
+            self._attr_options = _VENT_AIR_FLOW_OPTIONS_SMALL_VAM
+        else:
+            self._attr_options = _VENT_AIR_FLOW_OPTIONS_STANDARD_VAM
+
+        service.register_vent_hook(vent, self._status_change_hook)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device_info.unique_id)},
+            name=f"新风 {self._device_info.alias}",
+            manufacturer=MANUFACTURER,
+            via_device=(DOMAIN, self._device_info.gateway_id),
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current selected option."""
+        air_flow = self._device_info.status.air_flow
+        if air_flow is None:
+            return None
+        return _VENT_AIR_FLOW_BY_ENUM.get(air_flow)
+
+    def select_option(self, option: str) -> None:
+        """Select ventilation air flow."""
+        air_flow = _VENT_AIR_FLOW_BY_OPTION[option]
+        self._device_info.status.air_flow = air_flow
+        self._service.control_vent(
+            self._device_info,
+            VentilationStatus(air_flow=air_flow),
+        )
+        self.schedule_update_ha_state()
+
+    def _status_change_hook(self, **kwargs) -> None:
+        """Handle ventilation status changes."""
+        if kwargs.get("vent") is not None:
+            self._device_info = kwargs["vent"]
+
+        if kwargs.get("status") is not None:
+            new_status: VentilationStatus = kwargs["status"]
+            if new_status.air_flow is not None:
+                self._device_info.status.air_flow = new_status.air_flow
+
+        _log(f"vent air flow select updated: {self.current_option}")
+        self.schedule_update_ha_state()

--- a/custom_components/ds_air/sensor.py
+++ b/custom_components/ds_air/sensor.py
@@ -97,6 +97,8 @@ class DsVentSensor(SensorEntity):
         self._service = service
 
         sensor_info = SMALL_VAM_SENSOR_TYPES.get(data_key)
+        self._attr_has_entity_name = True
+        self._attr_translation_key = sensor_info[1] if sensor_info else data_key
         self._attr_unit_of_measurement = sensor_info[0] if sensor_info else None
         self._attr_device_class = sensor_info[2] if sensor_info else None
 

--- a/custom_components/ds_air/translations/en.json
+++ b/custom_components/ds_air/translations/en.json
@@ -68,5 +68,34 @@
         "description": "No AC for link"
       }
     }
+  },
+  "entity": {
+    "fan": {
+      "ventilation_switch": {
+        "name": "Switch"
+      }
+    },
+    "select": {
+      "ventilation_mode": {
+        "name": "Mode"
+      },
+      "ventilation_air_flow": {
+        "name": "Air flow"
+      }
+    },
+    "sensor": {
+      "indoor_temperature": {
+        "name": "Indoor temperature"
+      },
+      "outdoor_temperature": {
+        "name": "Outdoor temperature"
+      },
+      "outdoor_humidity": {
+        "name": "Outdoor humidity"
+      },
+      "outdoor_pm25": {
+        "name": "Outdoor PM2.5"
+      }
+    }
   }
 }

--- a/custom_components/ds_air/translations/zh-Hans.json
+++ b/custom_components/ds_air/translations/zh-Hans.json
@@ -68,5 +68,34 @@
         "description": "没有可操作的空调"
       }
     }
+  },
+  "entity": {
+    "fan": {
+      "ventilation_switch": {
+        "name": "开关"
+      }
+    },
+    "select": {
+      "ventilation_mode": {
+        "name": "模式"
+      },
+      "ventilation_air_flow": {
+        "name": "风量"
+      }
+    },
+    "sensor": {
+      "indoor_temperature": {
+        "name": "室内温度"
+      },
+      "outdoor_temperature": {
+        "name": "室外温度"
+      },
+      "outdoor_humidity": {
+        "name": "室外湿度"
+      },
+      "outdoor_pm25": {
+        "name": "室外PM2.5"
+      }
+    }
   }
 }

--- a/tests/test_ventilation_composite.py
+++ b/tests/test_ventilation_composite.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "custom_components" / "ds_air"))
+
+from ds_air_service.config import Config  # noqa: E402
+from ds_air_service.ctrl_enum import EnumDevice  # noqa: E402
+from ds_air_service.decoder import VentilationQueryCompositeSituationResult  # noqa: E402
+
+
+class FakeService:
+    def __init__(self):
+        self.room = None
+        self.unit = None
+        self.status = None
+
+    def set_ventilation_status(self, room, unit, status):
+        self.room = room
+        self.unit = unit
+        self.status = status
+
+
+class VentilationCompositeTests(unittest.TestCase):
+    def test_d611_composite_payload_with_bound_air_sensor(self):
+        config = Config()
+        config.is_d611 = True
+        payload = bytes.fromhex(
+            "010060db88c200ff020202fb000102040003022a00040240020502c300"
+            "060234000702040000010300ec94cb5ce00c0fe7a9bae6b094e4bca0"
+            "e6849fe599a8010200010202c3010302020304020700050249000601040000"
+        )
+        result = VentilationQueryCompositeSituationResult(1, EnumDevice.SMALL_VAM)
+        service = FakeService()
+
+        result.load_bytes(payload, config)
+        result.do(service)
+
+        self.assertEqual(service.room, 1)
+        self.assertEqual(service.unit, 0)
+        self.assertEqual(service.status.in_door_temp, 256)
+        self.assertEqual(service.status.out_door_temp, 195)
+        self.assertEqual(service.status.out_door_humidity, 52)
+        self.assertEqual(service.status.pm25, 4)
+
+    def test_d611_composite_payload_without_bound_air_sensor(self):
+        config = Config()
+        config.is_d611 = True
+        payload = bytes.fromhex(
+            "010060db88c200ff020202fb000102040003022a00040240020502c300"
+            "060234000702040000"
+        )
+        result = VentilationQueryCompositeSituationResult(1, EnumDevice.SMALL_VAM)
+        service = FakeService()
+
+        result.load_bytes(payload, config)
+        result.do(service)
+
+        self.assertEqual(service.room, 1)
+        self.assertEqual(service.unit, 0)
+        self.assertIsNone(service.status.in_door_temp)
+        self.assertEqual(service.status.out_door_temp, 195)
+        self.assertEqual(service.status.out_door_humidity, 52)
+        self.assertEqual(service.status.pm25, 4)
+
+    def test_legacy_composite_payload_keeps_existing_mapping(self):
+        config = Config()
+        payload = bytes.fromhex("01000102fa00020234000302c3000402070000")
+        result = VentilationQueryCompositeSituationResult(1, EnumDevice.SMALL_VAM)
+        service = FakeService()
+
+        result.load_bytes(payload, config)
+        result.do(service)
+
+        self.assertEqual(service.room, 1)
+        self.assertEqual(service.unit, 0)
+        self.assertEqual(service.status.in_door_temp, 250)
+        self.assertEqual(service.status.out_door_temp, 195)
+        self.assertEqual(service.status.out_door_humidity, 52)
+        self.assertEqual(service.status.pm25, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

这个 PR 改进了 DTA117D611 网关下的新风设备支持。

主要变更：

- 修复 DTA117D611 小型新风 composite payload 的解析
- 保留旧版 composite TLV 解析逻辑作为 fallback，避免影响 B611/C611 现有行为
- 增加 D611 composite payload 的单元测试
- 增加新风“模式”和“风量”两个 `select` 控制实体
- 增加新风相关实体名称的中英文翻译

## 背景

DTA117D611 在查询小型新风综合状态时，返回的 payload 不是旧逻辑假设的简单 TLV 结构。

实际抓包中发现，D611 的响应可能包含两个逻辑数据块：

1. 前半段 TLV：疑似新风自身数据
2. 后半段 named block：绑定的室内空气传感器数据

旧解析逻辑从 `room/unit` 后直接读取 `type/size/value`，会把 D611 payload 解析错位，导致新风传感器数据为空或错误。

## 解析调整

新的 D611 解析逻辑会先识别 composite payload 结构，并做如下映射：

- 前半段 `type 05` -> 室外温度
- 前半段 `type 06` -> 室外湿度
- 前半段 `type 07` -> 室外 PM2.5
- named air sensor block `type 01` -> 室内温度

如果没有识别到 D611 composite 结构，则回退到旧 TLV 解析逻辑。

同时修复了旧解析逻辑中 `type 3` 未读取的问题，现在会映射为室外温度。

## 控制实体

新增 `select` 平台，用于在设备页 Controls 中直接显示：

### 模式
- 内循环
- 热交换
- 自动
- 防污染
- 排异味

### 风量
- 静音
- 中速
- 高速
- 暴风（仅小型 VAM）

原有 fan 实体和 percentage 风量控制逻辑保持不变。

## 测试

已增加并通过以下测试：

```bash
python3 -m unittest tests/test_ventilation_composite.py tests/test_unique_ids.py
python3 -m py_compile custom_components/ds_air/ds_air_service/decoder.py tests/test_ventilation_composite.py