### PR TITLE
修复偶发的状态推送丢失（墙板操作不同步到 HA，重载可恢复）

### DIFF
--- a/custom_components/ds_air/ds_air_service/service.py
+++ b/custom_components/ds_air/ds_air_service/service.py
@@ -130,22 +130,40 @@ class SocketClient:
                     time.sleep(self._retry_sleep(deadline))
                     self.do_connect(deadline)
 
-    def recv(self) -> (list[BaseResult], bytes):
+    def _reconnect(self) -> None:
+        """断线后重连并重新握手。
+
+        网关只会向完成握手的连接推送状态变化，因此重连后必须重新发送握手，
+        否则墙板等设备上的状态变化不会再同步到 HA（只能依赖周期轮询）。
+        本方法仅由 RecvThread 调用，调用时未持有发送锁，故可安全调用 send()。
+        """
+        while self._ready and not self.do_connect():
+            time.sleep(self._retry_sleep(None))
+        if self._ready:
+            self.send(HandShakeParam())
+
+    def recv(self) -> list[BaseResult]:
         res = []
-        done = False
         data = None
 
-        while not done:
+        while True:
             try:
                 data = self._s.recv(1024)
-                done = True
             except Exception:
                 if not self._ready:
-                    return [], None
-                time.sleep(3)
-                self.do_connect()
-        if data is not None:
-            _log("recv hex: 0x" + data.hex())
+                    return []
+                # 真正的连接错误：重连并重新握手
+                self._reconnect()
+                continue
+            if data:
+                break
+            # recv 返回空字节表示对端已正常关闭连接（不会抛异常）。
+            # 必须重连并重新握手，否则会陷入空读忙循环，且网关不再推送状态。
+            if not self._ready:
+                return []
+            self._reconnect()
+
+        _log("recv hex: 0x" + data.hex())
         while data:
             try:
                 r, b = decoder(data, self._config)

--- a/custom_components/ds_air/ds_air_service/service.py
+++ b/custom_components/ds_air/ds_air_service/service.py
@@ -107,6 +107,10 @@ class SocketClient:
             self._s = None
             return False
         else:
+            # 该超时只用于建立连接阶段，不能残留到 RecvThread 中常驻的 recv()：
+            # 网关只在状态变化时推送，空闲间隔会远超该超时，否则 recv() 会超时抛错，
+            # 进而静默重连（且不重新握手），导致此后再也收不到状态推送。
+            self._s.settimeout(None)
             _log("connected")
             return True
 


### PR DESCRIPTION
### 问题现象
设备状态在外部变化后（例如直接在墙壁面板上操作），偶发不同步到 HA：

- **无任何错误日志**
- **偶发**，并非每次
- **重载集成可恢复**，过一段时间又复现

已知正常版本：`f467ad2`。

### 根因
回归由 491bbd1（"avoid blocking setup for unreachable gateway"）引入。

`SocketClient.do_connect()` 用 `settimeout()` 给套接字设了 5s 超时，本意只想约束 **建立连接** 阶段，避免连接不可达的网关时卡住 setup。但 `settimeout()` 是 **套接字级别的持久超时**，会作用于之后所有操作——包括 `RecvThread` 里常驻的 `recv(1024)`，而且连接成功后从未清除。已知正常版本 `f467ad2` 的套接字是纯阻塞、无超时，`recv()` 会一直阻塞等待网关推送。

失败链条：

1. setup 完成后，`RecvThread` 持续 `recv(1024)`，但带着 5s 超时。
2. 网关只在状态变化时推送，空闲间隔远超 5s → `recv()` 抛 `socket.timeout`。
3. 异常分支静默 `do_connect()` 重连，**新建一条 TCP 连接替换掉已握手的连接**。
4. 新连接 **没有重新握手**。网关只向完成握手/订阅（仅在 `init()` 做一次）的客户端推送 `STATUS_CHANGED`，于是墙板操作不再送达。
5. 新套接字又带 5s 超时 → 大约每 8s 反复重连、空转。

这完美对应现象：超时被吞 → 无日志；`poll_status` 周期轮询仍能拉到部分状态 + 网关固件健谈程度不同 → 偶发；重载会重跑 `init()` → 重新握手 → 推送恢复。

### 改动
两个独立提交：

**1. 修复连接超时残留（回归根因）**
- `do_connect()` 连接成功后 `settimeout(None)`，恢复阻塞模式，还原 `f467ad2` 的 `recv` 行为，同时保留 setup 阶段的连接超时。

**2. 加固重连逻辑（顺带修复两个既有隐患，`f467ad2` 也存在）**
- 对端正常关闭连接时 `recv()` 返回空字节（不抛异常），原逻辑会陷入 100% CPU 的空读忙循环且不重连——现按断连处理。
- 重连后从不重新握手，真实断线（网关重启、网络抖动）后推送会一直丢到下次重载——新增 `_reconnect()` 在重连成功后自动重发握手恢复订阅。`recv()` 的连接错误与空读两条路径统一走 `_reconnect()`；该方法仅由 `RecvThread` 调用、未持发送锁，与心跳线程的发送不会死锁。

仅改动 `custom_components/ds_air/ds_air_service/service.py`（+31 / −9）。

### 测试
- [x] 实机：DEBUG 日志确认不再每 ~8s 刷 `connected`；墙板改状态后 HA 即时同步
- [ ] 实机：手动断开网关电源/网络再恢复，日志出现一次重连 + 重新握手（room info / capability 重新查询），推送自动恢复，无需重载

### 风险与范围说明
- 半开连接（网关静默掉线、无 RST/FIN）仍依赖每 60s 心跳发送失败来触发重连——与已知正常版本一致，本 PR 未改动该并发路径以避免引入新竞态。若需让该场景也快速恢复，可另开 PR 做连接生命周期重构。

### 可能相关的 issue
#107 
#108 

fix #113 