### PR TITLE
fix: VOC传感器改用ENUM设备类，消除非数值状态报错

### DIFF
--- a/custom_components/ds_air/descriptions.py
+++ b/custom_components/ds_air/descriptions.py
@@ -22,8 +22,11 @@ FROZEN = MAJOR_VERSION >= 2024
 @dataclass(frozen=FROZEN, kw_only=True)
 class DsSensorEntityDescription(SensorEntityDescription):
     has_entity_name: bool = True
-    state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    state_class: SensorStateClass | None = SensorStateClass.MEASUREMENT
     value_fn: Callable[[Any], Any] | None = lambda x: x
+
+
+VOC_OPTIONS = ["优", "低", "中", "高"]
 
 
 SENSOR_DESCRIPTORS = {
@@ -59,8 +62,11 @@ SENSOR_DESCRIPTORS = {
     ),
     "voc": DsSensorEntityDescription(
         key="voc",
-        device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
-        value_fn=lambda x: str(x),  # EnumSensor.Voc
+        device_class=SensorDeviceClass.ENUM,
+        state_class=None,
+        options=VOC_OPTIONS,
+        # EnumSensor.Voc，不可用/未知等级映射为 None
+        value_fn=lambda x: s if (s := str(x)) in VOC_OPTIONS else None,
     ),
     "hcho": DsSensorEntityDescription(
         key="hcho",

--- a/custom_components/ds_air/ds_air_service/ctrl_enum.py
+++ b/custom_components/ds_air/ds_air_service/ctrl_enum.py
@@ -313,6 +313,7 @@ class EnumSensor:
                 return "中"
             if self.value == EnumSensor.Voc.STEP_4:
                 return "高"
+            return "不可用"
 
 
 # 新风模式列表


### PR DESCRIPTION
VOC上报的是等级枚举（优/低/中/高）而非ppb数值，原先的
volatile_organic_compounds_parts设备类+measurement状态类 在新版HA的数值强校验下报错。改为ENUM设备类并声明options；
STEP_UNUSE(127)及未知等级映射为None（unknown），与其他指标
不支持时的行为保持一致。Voc.__str__补充兜底返回值。

fix: #110 