### PR TITLE
修复第三代彩屏空气传感器 TVOC 和甲醛数值

### DIFF
--- a/custom_components/ds_air/descriptions.py
+++ b/custom_components/ds_air/descriptions.py
@@ -8,11 +8,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
     MAJOR_VERSION,
     PERCENTAGE,
+    UnitOfDensity,
+    UnitOfRatio,
     UnitOfTemperature,
 )
 
@@ -44,18 +43,18 @@ SENSOR_DESCRIPTORS = {
     ),
     "pm25": DsSensorEntityDescription(
         key="pm25",
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.PM25,
     ),
     "co2": DsSensorEntityDescription(
         key="co2",
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
         device_class=SensorDeviceClass.CO2,
     ),
     "tvoc": DsSensorEntityDescription(
         key="tvoc",
         name="TVOC",
-        native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
         suggested_display_precision=0,
         value_fn=lambda x: x * 10,
@@ -71,7 +70,7 @@ SENSOR_DESCRIPTORS = {
     "hcho": DsSensorEntityDescription(
         key="hcho",
         name="HCHO",
-        native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_CUBIC_METER,
+        native_unit_of_measurement=UnitOfDensity.MILLIGRAMS_PER_CUBIC_METER,
         value_fn=lambda x: x / 100,
     ),
 }

--- a/custom_components/ds_air/ds_air_service/decoder.py
+++ b/custom_components/ds_air/ds_air_service/decoder.py
@@ -430,10 +430,11 @@ class Sensor2InfoResult(BaseResult):
             sensor.pm25 = pm25
             sensor.co2 = co2
             sensor.voc = voc
-            if self._sensor_type == 3:
-                sensor.tvoc = tvoc
-                sensor.hcho = hcho
+            sensor.tvoc = tvoc
+            sensor.hcho = hcho
+            if tvoc != UNINITIALIZED_VALUE:
                 sensor.tvoc_upper = tvoc_upper
+            if hcho != UNINITIALIZED_VALUE:
                 sensor.hcho_upper = hcho_upper
             sensor.switch_on_off = switch_on_off
             sensor.temp_upper = temp_upper

--- a/tests/test_sensor2_info.py
+++ b/tests/test_sensor2_info.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import select  # noqa: F401 — preload stdlib select before ds_air/select.py
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "custom_components" / "ds_air"))
+
+from ds_air_service.config import Config  # noqa: E402
+from ds_air_service.ctrl_enum import EnumDevice  # noqa: E402
+from ds_air_service.decoder import Sensor2InfoResult  # noqa: E402
+
+
+class FakeService:
+    def __init__(self):
+        self.sensors = None
+
+    def set_sensors_status(self, sensors):
+        self.sensors = sensors
+
+
+class Sensor2InfoTests(unittest.TestCase):
+    def test_type4_sensor_stores_tvoc_and_hcho(self):
+        payload = bytes.fromhex(
+            "0102213b030001020304050606726f6f6d2d617f000d0125024000e001"
+            "0121000000011801ff7fff7fff7f4b000000e8030000023c000a00010101"
+            "16000800213a04010708090a0b0c06726f6f6d2d626f010401a8022c01fb"
+            "02c3000100011801ff7fff7fff7f4b000000e8030000023c000800010101"
+            "16000800"
+        )
+        result = Sensor2InfoResult(1, EnumDevice.SENSOR)
+        service = FakeService()
+
+        result.load_bytes(payload, Config())
+        result.do(service)
+
+        self.assertEqual(len(service.sensors), 2)
+        old_sensor, new_sensor = service.sensors
+        self.assertEqual(old_sensor.sensor_type, 3)
+        self.assertEqual(old_sensor.tvoc, 33)
+        self.assertEqual(old_sensor.hcho, 0)
+        self.assertEqual(new_sensor.sensor_type, 4)
+        self.assertEqual(new_sensor.tvoc, 195)
+        self.assertEqual(new_sensor.hcho, 1)
+        self.assertEqual(new_sensor.tvoc_upper, 60)
+        self.assertEqual(new_sensor.hcho_upper, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题背景

在接入大金最新第三代彩屏空气传感器后，Home Assistant 中的 TVOC 一直显示为 `0`，同时无法获得甲醛（HCHO）数值。大金 App 对这款传感器的 TVOC 使用优良中差等档位展示，与旧款空气传感器直接显示数值的方式不同。

实际网关报文表明，第三代彩屏空气传感器使用 `sensor_type=4`，并且仍然上报了有效的 TVOC 和 HCHO 数值。采集到的真实报文中，TVOC 原始值为 `195`，HCHO 原始值为 `1`。

## 根本原因

`Sensor2InfoResult` 已经根据 `type1` 能力位正确读取了 TVOC 和 HCHO 字段，但后续只有在 `sensor_type == 3` 时才会把读取结果写入传感器模型。

因此，第三代彩屏空气传感器虽然上报了有效数据，最终仍保留模型默认值 `0.0`。

## 修改内容

- 不再使用固定的 `sensor_type == 3` 判断保存 TVOC 和 HCHO。
- 根据报文能力位的实际解析结果写入 TVOC/HCHO 数值及对应阈值。
- 保持旧款 `sensor_type=3` 空气传感器的解析行为不变。
- 使用匿名化后的真实双传感器报文增加回归测试，同时覆盖 `sensor_type=3` 和 `sensor_type=4`。
- 将 Home Assistant 已弃用的浓度单位常量替换为 `UnitOfDensity` 和 `UnitOfRatio`。

## 用户影响

接入大金最新第三代彩屏空气传感器后，Home Assistant 可以正常获得其 TVOC 和甲醛数值，不再固定显示为 `0`。按照当前实体换算规则，上述真实报文对应 TVOC `1950 µg/m³`、HCHO `0.01 mg/m³`。

## 验证

- `python3 -m compileall -q custom_components/ds_air`
- `python3 -m unittest tests.test_sensor2_info tests.test_unique_ids tests.test_ventilation_composite -v`：8 项测试通过
- `git diff --check`
